### PR TITLE
Binding to privileged ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ are supported:
 - `discover`: Tries to find your HAProxy instance if you don't know the pid
 - `socket`: The location of the unix socket
 - [optional] `which`: The location of the HAProxy
+- [optional] `sudo`: If `true` start haproxy with `sudo`. Default is `false`
 
 There's a lot of freedom in this module, callbacks are always optional so you
 can do fire and forget management as well as how you add the callbacks.

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var slice = Array.prototype.slice;
  * - discover: Tries to find your HAProxy instance if you don't know the pid
  * - socket: The location of the unix socket
  * - [optional] which: The location of the haproxy
+ * - [optional] sudo: If `true` start haproxy with `sudo`. Default is `false`
  *
  * @see http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.2
  *
@@ -63,7 +64,8 @@ function HAProxy(socket, options) {
     pid: options.pid,
     pidFile: options.pidFile,
     discover: options.discover,
-    config: this.cfg
+    config: this.cfg,
+    sudo: options.sudo
   });
 }
 

--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -18,6 +18,7 @@ var run = require('child_process').exec
  * - config: The location of the configuration file
  * - [optional] discover: Tries to find your HAProxy instance if you don't know the pid
  * - [optional] which: The location of the haproxy
+ * - [optional] sudo: If `true` start haproxy with `sudo`. Default is `false`
  *
  * @constructor
  * @param {Object} options Orchestrator configuration.
@@ -33,11 +34,24 @@ function Orchestrator(options) {
   this.pidFile = options.pidFile || '';
   this.config = options.config;
   this.discover = options.discover || false;
+  this.sudo = options.sudo || false
+
+  //
+  // prefix haproxy commands with sudo if sudo is enabled
+  //
+  if (this.sudo) this.which = 'sudo ' + this.which;
 
   //
   // Discover a running process.
   //
   if (this.discover && !this.pid) this.read();
+
+  //
+  // We always launch HAProxy with a pidFile location. If we don't have one, we
+  // will default to a common location for pid files.
+  //
+  if (!this.pidFile) this.pidFile = '/var/run/haproxy.pid';
+
 }
 
 /**
@@ -93,12 +107,6 @@ Orchestrator.prototype.run = function ran() {
  */
 Orchestrator.prototype.start = function start(fn) {
   fn = fn.bind(this);
-
-  //
-  // We always launch HAProxy with a pidFile location. If we don't have one, we
-  // will default to a common location for pid files.
-  //
-  if (!this.pidFile) this.pidFile = '/var/run/haproxy.pid';
 
   //
   // Ensure that our pidFile actually existst.


### PR DESCRIPTION
To bind to privileged ports (e.g. 80, 443) haproxy needs be started with sudo or as root.   Have you found some magic way around this? Or do we need to add an option to invoke haproxy w/ sudo? 

I can craft a PR, just want to agree on approach... and need to make it work ASAP :)
