### PR TITLE
Read the pid of the active HAproxy process immediately before reload …

### DIFF
--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -213,23 +213,13 @@ Orchestrator.prototype.reload = function reload(hard, fn) {
   return this.verify(function verified(err) {
     if (err) return fn(err);
 
-    var current = this.pid;
+    this.read(function read(err, pid) {
 
-    this.run(cmd, this.config, this.pidFile, current, function ran(err, res, cmd) {
-      if (err) return fn(err);
-
-      //
-      // Poll for the change of pid.
-      //
-      (function piddy() {
-        this.read(function read(err, pid) {
-          if (err) return fn(err, undef, cmd);
-          if (pid !== current) return fn(undef, true, cmd);
-
-          setTimeout(piddy.bind(this), 100);
-        });
-      }.bind(this))();
-    });
+      var current = this.pid;
+      this.run(cmd, this.config, this.pidFile, current, function ran(err, res, cmd) {
+        return fn(err);
+      })
+    })
   });
 };
 


### PR DESCRIPTION
instead of polling afterwards.

The impetus for the change is that warnings in the haproxy config file will pass validation, but be seen as an error when starting the process ( although the process starts fine). In that case, we never poll for the pid, and we'll are out of sync. By reading the pid before we need it, we're more likely to have the right pid.

Note: in both cases we can still have orphaned haproxy processes if the user calls reload very fast in succession. The solution for that would be to read the PID from the spawned process, and track lifetime of the process better,

var process = run( ...., function(){
  // this is the pid of the created process.
   process.pid
}

process.on('exit ...