### PR TITLE
Fix config verification and reload error handling

### DIFF
--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -112,8 +112,9 @@ Orchestrator.prototype.start = function start(fn) {
     mkdirp.sync(pidDir);
   } catch (e) { return fn(e); }
 
-  return this.verify(function verified(err) {
+  return this.verify(function verified(err, verified) {
     if (err) return fn(err);
+    if (!verified) return fn(new Error('Invalid config'));
 
     this.run('haproxy -D -f %s -p %s', this.config, this.pidFile, function ran(err, res, cmd) {
       //
@@ -210,13 +211,14 @@ Orchestrator.prototype.reload = function reload(hard, fn) {
   var cmd = 'haproxy -D -f %s -p %s -sf %s';
   if (hard) cmd = 'haproxy -D -f %s -p %s -st %s';
 
-  return this.verify(function verified(err) {
+  return this.verify(function verified(err, verified) {
     if (err) return fn(err);
+    if (!verified) return fn(new Error('Invalid config'))
 
     var current = this.pid;
 
     this.run(cmd, this.config, this.pidFile, current, function ran(err, res, cmd) {
-      if (err) return fn(err);
+      if (err && !err.stderr) return fn(err, undef, cmd);
 
       //
       // Poll for the change of pid.
@@ -243,7 +245,7 @@ Orchestrator.prototype.verify = function verify(fn) {
   fn = fn.bind(this);
 
   return this.run('haproxy -c -f %s', this.config, function verified(err, res, cmd) {
-    fn(undefined, !err && !!res, cmd);
+    fn(undefined, !(err && !err.stderr), cmd);
   });
 };
 


### PR DESCRIPTION
Currently all `this.verify()` calls only check the error response, which is always `undefined`. This PR adds a `verified` argument to those calls which indicates whether the config is valid. The verification status is determined by checking only the error status of the `haproxy -c` command (ignoring stderr errors), since it exits with `1` if the config is invalid.

This PR also ignores stderr errors in `reload()`, since there may be warnings and the process will exit with `1` if it fails to start correctly.