### PR TITLE
use readFileSync for reading pid file

### DIFF
--- a/lib/orchestrator.js
+++ b/lib/orchestrator.js
@@ -281,11 +281,15 @@ Orchestrator.prototype.read = function read(fn) {
   if (fn) fn = fn.bind(this);
 
   if (this.pidFile) {
-    fs.readFile(this.pidFile, 'utf-8', function reader(err, pid, cmd) {
-      this.pid = (pid || '').trim();
+    if (fn) {
+      fs.readFile(this.pidFile, 'utf-8', function reader(err, pid, cmd) {
+        this.pid = (pid || '').trim();
 
-      if (fn) fn(err, this.pid, cmd);
-    }.bind(this));
+        fn(err, this.pid, cmd);
+      }.bind(this));
+    } else {
+      this.pid = (fs.readFileSync(this.pidFile, 'utf-8') || '').trim();
+    }
     return this;
   }
 


### PR DESCRIPTION
When initialising HAProxy using ```new HAProxy()```, it asynchronously reads the _pid_ file.
So, calling ```haproxy.reload()``` after initialising, results in _pid_ as ""(empty string) as the _pid_ file has not yet read.
This PR fixes the issue by using ```readFileSync``` for reading pid if there is no callback provided to ```Orchestrator.prototype.read```